### PR TITLE
create `useEleventy` helper

### DIFF
--- a/src/EleventyContext.jsx
+++ b/src/EleventyContext.jsx
@@ -1,0 +1,17 @@
+import { createContext } from "preact";
+import { useContext } from "preact/hooks";
+
+const EleventyContext = createContext(undefined);
+
+export const page = (getPage) =>
+	function () {
+		return (
+			<EleventyContext.Provider value={this}>
+				{getPage()}
+			</EleventyContext.Provider>
+		);
+	};
+
+export function useEleventy() {
+	return useContext(EleventyContext);
+}

--- a/src/EleventyContext.jsx
+++ b/src/EleventyContext.jsx
@@ -3,14 +3,15 @@ import { useContext } from "preact/hooks";
 
 const EleventyContext = createContext(undefined);
 
-export const page = (getPage) =>
-	function () {
+export function page(getPage) {
+	return function () {
 		return (
 			<EleventyContext.Provider value={this}>
-				{getPage()}
+				{getPage.bind(this)()}
 			</EleventyContext.Provider>
 		);
 	};
+}
 
 export function useEleventy() {
 	return useContext(EleventyContext);

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,6 +1,7 @@
 import { page, useEleventy } from "../EleventyContext.jsx";
 
-export default page(() => {
+export default page(function () {
+	console.log(this);
 	return (
 		<html lang="en">
 			<head>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,4 +1,6 @@
-export default function Page() {
+import { page, useEleventy } from "../EleventyContext.jsx";
+
+export default page(() => {
 	return (
 		<html lang="en">
 			<head>
@@ -8,7 +10,15 @@ export default function Page() {
 			</head>
 			<body>
 				<h1>Hello!</h1>
+				<Test />
 			</body>
 		</html>
 	);
-}
+});
+
+const Test = () => {
+	const eleventy = useEleventy();
+	console.log(eleventy);
+
+	return null;
+};


### PR DESCRIPTION
This stores the page's `this` context in a Preact context and makes it available to all components through the `useEleventy` hook. Just wrap the page entrypoint in `page`.